### PR TITLE
Feature: nextInteger, nextInteger32, and nextArray normalization

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,8 +95,8 @@ Array functions must be used instead of single-value functions to get the additi
 const gen = new RandomGenerator();
 const randomArray = gen.nextArray_BigInt();           // 1000 unsigned BigInts
 const randomArray2 = gen.nextArray_Integer();         // 1000 unsigned integer Numbers
-const randomArray2 = gen.nextArray_Integer32();       // 1000 unsigned integer Numbers
-const randomArray3 = gen.nextArray_Number();          // 1000 float Numbers in [0, 1)
+const randomArray3 = gen.nextArray_Integer32();       // 1000 unsigned integer Numbers
+const randomArray4 = gen.nextArray_Number();          // 1000 float Numbers in [0, 1)
 ```
 
 #### ⚠️Shared Buffer Warning⚠️

--- a/README.md
+++ b/README.md
@@ -1,28 +1,27 @@
 # fast-prng-wasm
 [![GitHub license](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/themattspiral/fast-prng-wasm/blob/main/LICENSE.md) [![npm version](https://img.shields.io/npm/v/fast-prng-wasm.svg?style=flat)](https://www.npmjs.com/package/fast-prng-wasm)
 
-A collection of fast, SIMD-enabled pseudo random number generators that run in WebAssembly.
+A collection of fast, SIMD-enabled pseudo random number generators that run in [WebAssembly](https://developer.mozilla.org/en-US/docs/WebAssembly).
 
 ### Features:
 - Simple usage from JavaScript
 - Supports both Node and browsers
-- Transparent, synchronous WASM loading (embedded binaries - no `fs` or `fetch`)
+- Transparent, synchronous WASM loading (embedded binaries - no `fs` or `fetch` required)
 - Seedable (or auto-seeded)
 - Jumpable (for shared-seed/unique-stream parallelization)
-- Single value and bulk array outputs
-- Designed for speed - SIMD versions allow higher throughput
+- Float, Integer, and BigInt outputs
+- Single value and bulk array functions
+- Designed for speed - [WASM SIMD](https://github.com/WebAssembly/simd/blob/master/proposals/simd/SIMD.md) versions allow higher throughput
 - Can be imported to other [AssemblyScript](https://www.assemblyscript.org/) projects as part of a larger WASM compilation
 
 ### PRNG Algorithms:
-- `PRNG.PCG` (PCG XSH RR): 32-bit generator with 64 bits of state
-- `PRNG.Xoroshiro128Plus` (Xoroshiro128+): 32-bit generator with 128 bits of state, and period of 2<sup>128</sup>
-- `PRNG.Xoroshiro128Plus_SIMD` (Xoroshiro128+): 32-bit generator with 128 bits of state, and period of 2<sup>128</sup>
-  - This version is SIMD-enabled, and so provides 2 random outputs for the price of 1
-- `PRNG.Xoshiro256Plus` (Xoshiro256+): 64-bit generator with 256 bits of state, and period of 2<sup>256</sup>
-- `PRNG.Xoshiro256Plus_SIMD` (Xoshiro256+): 64-bit generator with 256 bits of state, and period of 2<sup>256</sup>
-  - This version is SIMD-enabled, and so provides 2 random outputs for the price of 1
+- **PCG XSH RR:** 32-bit generator with 64 bits of state
+- **Xoroshiro128+:** 64-bit generator with 128 bits of state (2<sup>128</sup> period)
+- **Xoroshiro128+ (SIMD):** A SIMD-enabled version of above; provides 2 random outputs for the price of 1
+- **Xoshiro256+:** 64-bit generator with 256 bits of state (2<sup>256</sup> period)
+- **Xoshiro256+ (SIMD):** SIMD-enabled version of above; provides 2 random outputs for the price of 1
 
-#### Further Reading:
+#### Further PRNG Reading:
 - [PCG: A Family of Better Random Number Generators](https://www.pcg-random.org)
 - [`xoshiro` / `xoroshiro` generators and the PRNG shootout](https://prng.di.unimi.it/)
 
@@ -43,12 +42,16 @@ A collection of fast, SIMD-enabled pseudo random number generators that run in W
 
 ### Basics
 ``` js
-const gen = new RandomGenerator();    // default is Xoroshiro128Plus_SIMD
-console.log(gen.nextBigInt());        // random 64-bit BigInt value
-console.log(gen.nextNumber());        // random float Number in [0, 1)
+const gen = new RandomGenerator();      // default is Xoroshiro128Plus_SIMD
+console.log(gen.nextBigInt());          // random 64-bit BigInt value
+console.log(gen.nextIntegerNumber());   // random 53-bit integer value as a Number
+console.log(gen.nextNumber());          // random float Number in [0, 1)
 
-const pcgGen = new RandomGenerator(PRNGType.PCG);   // a PCG generator
-console.log(pcgGen.nextNumber());     // random float Number in [0, 1)
+// a PCG generator, exposing the same interface
+const pcgGen = new RandomGenerator(PRNGType.PCG);
+console.log(gen.nextBigInt());          // random 64-bit BigInt value
+console.log(gen.nextIntegerNumber());   // random 53-bit integer value as a Number
+console.log(gen.nextNumber());          // random float Number in [0, 1)
 ```
 
 ### Seeding
@@ -59,6 +62,8 @@ const customSeeds = [7n, 9876543210818181n];
 const customSeededGen = new RandomGenerator(PRNGType.Xoroshiro128Plus, customSeeds);
 
 // 2) auto-generated seed set, shared between multiple generators
+// Uses SplitMix64 generator (with current time and Math.random seeds) to
+// generate 8 random 64-bit seeds suitable for any PRNG type in this lib
 const sharedSeeds = seed64Array();    // Array<bigint> (8)
 
 const seededGen1 = new RandomGenerator(PRNGType.Xoshiro256Plus, sharedSeeds);
@@ -84,27 +89,35 @@ The fastest way to get random numbers in bulk is to use the `nextArray_*` method
 #### 💡 SIMD
 Array functions must be used instead of single-value functions to get the additional throughput offered by SIMD algorithm types (these have higher throughput because they produce multiple numbers at the same time).
 
-#### ⚠️Warning
-Because you are consuming random numbers out of a view on a portion of shared WebAssembly memory, and this memory is reused between calls to the `nextArray_*` functions, you must actually consume (e.g. test/calculate, or copy) these numbers between each call.
+``` js
+const gen = new RandomGenerator();
+const randomArray = gen.nextArray_BigInts();          // 1000 unsigned BigInts
+const randomArray2 = gen.nextArray_IntegerNumbers();  // 1000 unsigned integer Numbers
+const randomArray3 = gen.nextArray_Numbers();         // 1000 float Numbers in [0, 1)
+```
+
+#### ⚠️Shared Buffer Warning⚠️
+Because you are consuming random numbers out of a view on a portion of shared WebAssembly memory, and this *memory is reused between calls* to the `nextArray_*` functions, **you must actually consume (e.g. test/calculate, or copy) these numbers between each call**.
 
 ``` js
 const gen = new RandomGenerator();
-const randomArray1 = gen.nextArray_Numbers();   // 1000 random floats in [0, 1)
 
-// ⚠️ Warning: Consume these numbers before making another call to nextArray_*
+// ⚠️Warning⚠️: Consume these numbers before making another call to nextArray_*
+const randomArray1 = gen.nextArray_Numbers();   // 1000 float Numbers in [0, 1)
 console.log(randomArray1);
 
-const randomArray2 = gen.nextArray_Numbers();   // 1000 more floats in [0, 1)
+// the values originally in randomArray1 will be replaced now!
+const randomArray2 = gen.nextArray_Numbers();   // 1000 floats in [0, 1)
 console.log(randomArray2);
 
-// Take Note!
 console.log(randomArray1 === randomArray2);     // true (same buffer!)
 ```
 
 #### Array Size
 ``` js
-const gen = new RandomGenerator();
-const randomArray = gen.nextArray_Numbers();    // 1000 random floats in [0, 1)
+// providing null seeds on instantiation will auto-seed the generator
+const gen = new RandomGenerator(PRNGType.PCG, null, 0, 200);
+const randomArray = gen.nextArray_Numbers();    // 200 random floats in [0, 1)
 
 // resize output buffer reserved by WASM instance
 gen.outputArraySize = 42;                       // change output array size
@@ -120,36 +133,42 @@ The AssemblyScript configuration in `asconfig.release.json` specifies a fixed WA
 If for some reason you need a larger array, you can increase the configured memory size and [rebuild the library](#working-with-this-repo).
 
 
-
-
-
-
-
-
-
-
 ## JavaScript API
 Docs coming soon.
 
 Code contains JSDoc comments which should be visible in IDEs.
 
+Also see [`RandomGenerator` source](https://github.com/themattspiral/fast-prng-wasm/blob/main/src/random-generator.js).
+
 
 ## AssemblyScript API
 Docs coming soon.
 
-For now, see `RandomGenerator` source, and/or individual generator AssemblyScript source to see the interface.
+For now, see individual generator [AssemblyScript source](https://github.com/themattspiral/fast-prng-wasm/tree/main/src/assembly) to see the interface.
 
 
 ## Compatibility
-Coming soon.
+See the [WebAssembly Features Roadmap](https://webassembly.org/features/) for the latest compatibility information across various browsers and Node versions.
+
+Note that this library makes use of the following feature extensions:
+- [JS BigInt to Wasm i64 Integration](https://github.com/WebAssembly/JS-BigInt-integration) - Any function that returns `BigInt`s uses this feature
+- [Fixed-width SIMD](https://github.com/WebAssembly/simd/blob/master/proposals/simd/SIMD.md) - Any SIMD PRNG Algorithm Type uses this feature
 
 
 ## Demos
-See the `demo/` folder for all available demos. Each one is treated as a separate project:
-- **`pmc`**: Pi Monte Carlo - A [Monte Carlo estimation of pi (π)](https://www.geeksforgeeks.org/estimating-value-pi-using-monte-carlo/) using a large quantity of random numbers
+See the [`demo/` folder](https://github.com/themattspiral/fast-prng-wasm/tree/main/demo) for all available demos. Each one is treated as a separate project.
+- [**`pmc` - Pi Monte Carlo:**](https://github.com/themattspiral/fast-prng-wasm/tree/main/demo/pmc) A Monte Carlo estimation of pi (π) using a large quantity of random numbers
+  - Node CLI demo app
+  - Uses multiple generator instances (one per worker thread)
+  - Shares a single seed set across generators
+  - Uses generator jump function to select unique stream per worker
 
 
 ## Working With This Repo
 Coming soon.
 
 For now, see scripts in `package.json`.
+
+
+## Roadmap
+Planned features are listed in [TODO.md](https://github.com/themattspiral/fast-prng-wasm/blob/main/TODO.md)

--- a/TODO.md
+++ b/TODO.md
@@ -1,15 +1,22 @@
 ## TODO
 
-This library is currently a work-in-progress hobby project in alpha stage.As such, the interface is subject to change and shift somewhat still until reaching v1.0.0.
+This library is currently a work-in-progress, hobby project in alpha stage.
 
-## Possible Features
-- types
-- typescript conversion
-- feature detection
-- next32 across generators
-- bounded integer output
+As such, the interface is subject to change and shift somewhat, until reaching v1.0.0.
+
+## Roadmap
+Feel free to [suggest features and report any issues](https://github.com/themattspiral/fast-prng-wasm/issues) you encounter.
+
+### Features
 - PCG jump (change increment value)
-- perf (pi) demo - Node
-- web demo (maybe using unpkg umd) 
-- assemblyscript demo
-- github actions?
+- Bounded integer output
+- WASM feature detection (SIMD)
+- web demo 
+- assemblyscript consumer demo
+- cache second output when returning single values from SIMD types to force output streams to match between single and array?
+
+### Tech Debt
+- type definitions
+- source typescript conversion
+- CI/CD github actions
+- tests

--- a/demo/pmc/README.md
+++ b/demo/pmc/README.md
@@ -6,8 +6,17 @@ A [Monte Carlo estimation of pi (π)](https://www.geeksforgeeks.org/estimating-v
 - This project is a good example of using a single set of shared seeds across multiple generators, combined with using unique `jumpCount` values (on generator creation) to select a unique random stream for each generator.
 
 ## Install Demo Deps & Run
-💡 Assumes your working directory is `demo/pmc/`
+This demo uses a local dependency for `fast-prng-wasm`, so you must build it first (or install a published version instead). 
+
+In the project root:
 ``` sh
+npm i
+npm run build
+```
+ 
+Change directory to `demo/pmc`, install dependencies, and run:
+``` sh
+cd demo/pmc
 npm i
 node pmc.js
 ```

--- a/demo/pmc/package-lock.json
+++ b/demo/pmc/package-lock.json
@@ -1,16 +1,26 @@
 {
   "name": "pmc",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pmc",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "MIT",
       "dependencies": {
         "bignumber.js": "^9.1.2",
-        "fast-prng-wasm": "^0.3.1"
+        "fast-prng-wasm": "file:../.."
+      }
+    },
+    "../..": {
+      "version": "0.3.4",
+      "license": "MIT",
+      "devDependencies": {
+        "@rollup/plugin-wasm": "^6.2.2",
+        "assemblyscript": "~0.27.31",
+        "rollup": "^4.27.3",
+        "rollup-plugin-copy": "^3.5.0"
       }
     },
     "node_modules/bignumber.js": {
@@ -23,10 +33,8 @@
       }
     },
     "node_modules/fast-prng-wasm": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/fast-prng-wasm/-/fast-prng-wasm-0.3.1.tgz",
-      "integrity": "sha512-TXl//BfdEX1OMEK6u7VhR1kKUECJGFZioLoigiImJgiRd9uLifEut4Cifc8GzGSGXLdHhG3DiHiss79QBD+ULQ==",
-      "license": "MIT"
+      "resolved": "../..",
+      "link": true
     }
   }
 }

--- a/demo/pmc/package.json
+++ b/demo/pmc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pmc",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Pi Monte Carlo - A Monte Carlo pi (π) estimation for node, using worker_threads and fast-prng-wasm for speedy random point generation",
   "author": "Matt Ritter (matthew.d.ritter@gmail.com)",
   "license": "MIT",
@@ -11,6 +11,6 @@
   },
   "dependencies": {
     "bignumber.js": "^9.1.2",
-    "fast-prng-wasm": "^0.3.1"
+    "fast-prng-wasm": "file:../.."
   }
 }

--- a/demo/pmc/worker.js
+++ b/demo/pmc/worker.js
@@ -32,7 +32,7 @@ if (!isMainThread) {
             // each point we test consums 2 numbers from the output array, 
             // so point batch size can be at most half of the output array size.
             const batchPointCount = Math.min(generator.outputArraySize / 2, workerData.pointCount - pointsGenerated);
-            const nums = generator.nextArray_CoordsSquared();
+            const nums = generator.nextArray_CoordSquared();
 
             for (let i = 0; i < batchPointCount * 2; i += 2) {
                 if (nums[i] + nums[i + 1] <= 1) {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   ],
   "devDependencies": {
     "@rollup/plugin-wasm": "^6.2.2",
-    "assemblyscript": "^0.27.31",
+    "assemblyscript": "~0.27.31",
     "rollup": "^4.27.3",
     "rollup-plugin-copy": "^3.5.0"
   },

--- a/src/assembly/common-simd.ts
+++ b/src/assembly/common-simd.ts
@@ -4,21 +4,44 @@ export const BIT_53x2: v128 = f64x2.splat(BIT_53);
 export const ONEx2: v128 = f64x2.splat(1.0);
 export const TWOx2: v128 = f64x2.splat(2.0);
 
-// return 2 random f64 numbers in range [0, 1)
+// return 2 random 53-bit integers between 0 and 2^53 - 1,
+// as f64s so that JS converts them to Numbers
 @inline
-export function numbers(next: v128): v128 {
+export function int53Numbers(next: v128): v128 {
     // Shift right by 11 (>> 11) to extract upper 53 bits
-    // (highest quality randomness in upper, and f64 only supports 53 bit precision)
+    // of each output (highest quality randomness in upper,
+    // and JS `Number` only supports 53 bit precision)
     const randShifted: v128 = v128.shr<u64>(next, 11);
 
     // extract bit-shifted u64s and cast to f64s
-    const n: v128 = f64x2(
+    return f64x2(
         <f64>v128.extract_lane<u64>(randShifted, 0),
         <f64>v128.extract_lane<u64>(randShifted, 1)
     );
+}
+
+// return 2 random 32-bit integers between 0 and 2^32 - 1,
+// as f64s so that JS converts them to Numbers
+@inline
+export function int32Numbers(next: v128): v128 {
+    // Shift right by 32 (>> 32) to extract upper 32 bits
+    // of each output (highest quality randomness in upper)
+    const randShifted: v128 = v128.shr<u64>(next, 32);
+
+    // extract bit-shifted u64s and cast to f64s
+    return f64x2(
+        <f64>v128.extract_lane<u64>(randShifted, 0),
+        <f64>v128.extract_lane<u64>(randShifted, 1)
+    );
+}
+
+// return 2 random f64 numbers in range [0, 1)
+@inline
+export function numbers(next: v128): v128 {
+    const randShifted: v128 = int53Numbers(next);
     
     // Scale:  number / 2^53 to get range [0, 1)
-    return v128.div<f64>(n, BIT_53x2);
+    return v128.div<f64>(randShifted, BIT_53x2);
 }
 
 // return 2 random f64 numbers in range (-1, 1)

--- a/src/assembly/common.ts
+++ b/src/assembly/common.ts
@@ -3,6 +3,20 @@
 export const JUMP_128: StaticArray<u64> = [0x2bd7a6a6e99c2ddc, 0x0992ccaf6a6fca05];
 export const JUMP_256: StaticArray<u64> = [0x180ec6d33cfd0aba, 0xd5a61266f0c9392c, 0xa9582618e03fc9aa, 0x39abdc4529b1661c];
 
+@inline
+// return a random 53-bit integer between 0 and 2^53 - 1
+// as an f64 so that JS converts it to Number
+export function int53Number(next: u64): f64 {
+    return <f64>(next >> 11);
+}
+
+@inline
+// return a random 32-bit integer between 0 and 2^32 - 1
+// as an f64 so that JS converts it to Number
+export function int32Number(next: u64): f64 {
+    return <f64>(next >> 32);
+}
+
 // return a random f64 number in range [0, 1)
 @inline
 export function number(next: u64): f64 {

--- a/src/assembly/xoroshiro128plus-simd.ts
+++ b/src/assembly/xoroshiro128plus-simd.ts
@@ -1,5 +1,5 @@
-import { number, coord, coordSquared, JUMP_128 } from './common';
-import { numbers, point, pointSquared } from './common-simd';
+import { int32Number, int53Number, number, coord, coordSquared, JUMP_128 } from './common';
+import { int32Numbers, int53Numbers, numbers, point, pointSquared } from './common-simd';
 
 let s0: v128 = i64x2.splat(0);
 let s1: v128 = i64x2.splat(0);
@@ -7,16 +7,18 @@ let s1: v128 = i64x2.splat(0);
 export function setSeed(a: u64, b: u64, c: u64, d: u64): void {
     s0 = i64x2(a, c);
     s1 = i64x2(b, d);
-    nextU64x2();
+    nextInt64x2();
 };
 
-// advances the state by 2^64 steps every call.
-// can be used to generate 2^64 non-overlapping subsequences for parallel computations.
+/**
+ * Advances the state by 2^64 steps every call. Can be used to generate 2^64 
+ * non-overlapping subsequences (with the same seed) for parallel computations.
+ */
 export function jump(): void {  
     let jump_s0: v128 = i64x2.splat(0);
     let jump_s1: v128 = i64x2.splat(0);
   
-    // loop through each 64-bit value in the JUMP_128 array
+    // loop through each 64-bit value in the jump array
     for (let i: i32 = 0; i < JUMP_128.length; i++) {
         // loop through each bit of the jump value, and if bit is 1, compute a new jump state
         for (let b: i32 = 0; b < 64; b++) {
@@ -24,7 +26,7 @@ export function jump(): void {
                 jump_s0 = v128.xor(jump_s0, s0);
                 jump_s1 = v128.xor(jump_s1, s1);
             }
-            nextU64x2();
+            nextInt64x2();
         }
     }
   
@@ -34,7 +36,7 @@ export function jump(): void {
 }
 
 @inline
-export function nextU64x2(): v128 {
+export function nextInt64x2(): v128 {
     const result: v128 = v128.add<u64>(s0, s1);
     const t: v128 = v128.xor(s1, s0);
 
@@ -51,55 +53,69 @@ export function nextU64x2(): v128 {
     return result;
 };
 
-/**
- * No runtime function call penalty is incurred here because 
- * we inline and optimize the build at compile time.
- */
+// No runtime function call penalty is incurred here because 
+// we inline and optimize the build at compile time
+@inline
+export function nextInt53x2(): v128 {
+    return int53Numbers(nextInt64x2());
+}
+
+@inline
+export function nextInt32x2(): v128 {
+    return int32Numbers(nextInt64x2());
+}
+
 @inline
 export function nextNumbers(): v128 {
-    return numbers(nextU64x2());
+    return numbers(nextInt64x2());
 }
 
 @inline
 export function nextPoint(): v128 {
-    return point(nextU64x2());
+    return point(nextInt64x2());
 }
 
 @inline
 export function nextPointSquared(): v128 {
-    return pointSquared(nextU64x2());
+    return pointSquared(nextInt64x2());
 }
 
-/**
- * Single-number functions are provided for interface compatibility, but
- * do not actually take advantage of parallelization achieved with SIMD.
- */
+// Single-number functions are provided for interface compatibility, but
+// do not actually take advantage of parallelization achieved with SIMD
 @inline
-export function next(): u64 {
-    return v128.extract_lane<u64>(nextU64x2(), 0);
+export function nextInt64(): u64 {
+    return v128.extract_lane<u64>(nextInt64x2(), 0);
+}
+
+@inline
+export function nextInt53Number(): f64 {
+    return int53Number(nextInt64());
+}
+
+@inline
+export function nextInt32Number(): f64 {
+    return int32Number(nextInt64());
 }
 
 @inline
 export function nextNumber(): f64 {
-    return number(v128.extract_lane<u64>(nextU64x2(), 0));
+    return number(v128.extract_lane<u64>(nextInt64x2(), 0));
 }
 
 @inline
 export function nextCoord(): f64 {
-    return coord(v128.extract_lane<u64>(nextU64x2(), 0));
+    return coord(v128.extract_lane<u64>(nextInt64x2(), 0));
 }
 
 @inline
 export function nextCoordSquared(): f64 {
-    return coordSquared(v128.extract_lane<u64>(nextU64x2(), 0));
+    return coordSquared(v128.extract_lane<u64>(nextInt64x2(), 0));
 }
 
-/**
- * Expose array management functions from this module.
- */
+// Expose array management functions from this module
 export { allocUint64Array, allocFloat64Array, freeArray } from './common';
 
-/**
+/*
  * If we extract the following mostly-repeated functions to shared logic, 
  * define a type for the function, and pass the generator function as a 
  * parameter, it runs somewhat slower because of runtime function call overhead
@@ -112,7 +128,7 @@ export { allocUint64Array, allocFloat64Array, freeArray } from './common';
  *  Everything slows down. So we opt instead for static functions and speed.
  */
 
-// Monte Carlo test: Count how many random points fall inside a unit circle
+/** Monte Carlo test: Count how many random points fall inside a unit circle */
 export function batchTestUnitCirclePoints(pointCount: i32): i32 {
     let pointsInCircle: i32 = 0;
     let pSquared: v128;
@@ -132,13 +148,33 @@ export function batchTestUnitCirclePoints(pointCount: i32): i32 {
     return pointsInCircle;
 }
 
-export function fillUint64Array(arr: Uint64Array): void {
+export function fillUint64Array_Int64(arr: Uint64Array): void {
     let rand: v128;
 
     for (let i: i32 = 0; i < arr.length - 1; i += 2) {
-        rand = nextU64x2();
+        rand = nextInt64x2();
         unchecked(arr[i] = v128.extract_lane<u64>(rand, 0));
         unchecked(arr[i + 1] = v128.extract_lane<u64>(rand, 1));
+    }
+}
+
+export function fillFloat64Array_Int53Numbers(arr: Float64Array): void {
+    let rand: v128;
+
+    for (let i: i32 = 0; i < arr.length - 1; i += 2) {
+        rand = nextInt53x2();
+        unchecked(arr[i] = v128.extract_lane<f64>(rand, 0));
+        unchecked(arr[i + 1] = v128.extract_lane<f64>(rand, 1));
+    }
+}
+
+export function fillFloat64Array_Int32Numbers(arr: Float64Array): void {
+    let rand: v128;
+
+    for (let i: i32 = 0; i < arr.length - 1; i += 2) {
+        rand = nextInt32x2();
+        unchecked(arr[i] = v128.extract_lane<f64>(rand, 0));
+        unchecked(arr[i + 1] = v128.extract_lane<f64>(rand, 1));
     }
 }
 

--- a/src/assembly/xoroshiro128plus.ts
+++ b/src/assembly/xoroshiro128plus.ts
@@ -1,4 +1,4 @@
-import { number, coord, coordSquared, JUMP_128 } from './common';
+import { int32Number, int53Number, number, coord, coordSquared, JUMP_128 } from './common';
 
 let s0: u64 = 0;
 let s1: u64 = 0;
@@ -6,16 +6,18 @@ let s1: u64 = 0;
 export function setSeed(a: u64, b: u64): void {
     s0 = a;
     s1 = b;
-    next();
+    nextInt64();
 };
 
-// advances the state by 2^64 steps every call.
-// can be used to generate 2^64 non-overlapping subsequences for parallel computations.
+/**
+ * Advances the state by 2^64 steps every call. Can be used to generate 2^64 
+ * non-overlapping subsequences (with the same seed) for parallel computations.
+ */
 export function jump(): void {  
     let jump_s0: u64 = 0;
     let jump_s1: u64 = 0;
   
-    // loop through each 64-bit value in the JUMP_128 array
+    // loop through each 64-bit value in the jump array
     for (let i: i32 = 0; i < JUMP_128.length; i++) {
         // loop through each bit of the jump value, and if bit is 1, compute a new jump state
         for (let b: i32 = 0; b < 64; b++) {
@@ -23,7 +25,7 @@ export function jump(): void {
                 jump_s0 ^= s0;
                 jump_s1 ^= s1;
             }
-            next();
+            nextInt64();
         }
     }
   
@@ -33,7 +35,7 @@ export function jump(): void {
 }
 
 @inline
-export function next(): u64 {
+export function nextInt64(): u64 {
     const result: u64 = s0 + s1;
     const t: u64 = s1 ^ s0;
 
@@ -43,31 +45,37 @@ export function next(): u64 {
     return result;
 };
 
-/**
- * No runtime function call penalty is incurred here because 
- * we inline and optimize the build at compile time.
- */
+// No runtime function call penalty is incurred here because 
+// we inline and optimize the build at compile time
+@inline
+export function nextInt53Number(): f64 {
+    return int53Number(nextInt64());
+}
+
+@inline
+export function nextInt32Number(): f64 {
+    return int32Number(nextInt64());
+}
+
 @inline
 export function nextNumber(): f64 {
-    return number(next());
+    return number(nextInt64());
 }
 
 @inline
 export function nextCoord(): f64 {
-    return coord(next());
+    return coord(nextInt64());
 }
 
 @inline
 export function nextCoordSquared(): f64 {
-    return coordSquared(next());
+    return coordSquared(nextInt64());
 }
 
-/**
- * Expose array management functions from this module.
- */
+// Expose array management functions from this module
 export { allocUint64Array, allocFloat64Array, freeArray } from './common';
 
-/**
+/*
  * If we extract the following mostly-repeated functions to shared logic, 
  * define a type for the function, and pass the generator function as a 
  * parameter, it runs somewhat slower because of runtime function call overhead
@@ -80,7 +88,7 @@ export { allocUint64Array, allocFloat64Array, freeArray } from './common';
  *  Everything slows down. So we opt instead for static functions and speed.
  */
 
-// Monte Carlo test: Count how many random points fall inside a unit circle
+/** Monte Carlo test: Count how many random points fall inside a unit circle */
 export function batchTestUnitCirclePoints(count: i32): i32 {
     let inCircle: i32 = 0;
     let xSquared: f64;
@@ -98,9 +106,20 @@ export function batchTestUnitCirclePoints(count: i32): i32 {
     return inCircle;
 }
 
-export function fillUint64Array(arr: Uint64Array): void {
+export function fillUint64Array_Int64(arr: Uint64Array): void {
     for (let i: i32 = 0; i < arr.length; i++) {
-        unchecked(arr[i] = next());
+        unchecked(arr[i] = nextInt64());
+    }
+}
+
+export function fillFloat64Array_Int53Numbers(arr: Float64Array): void {
+    for (let i: i32 = 0; i < arr.length; i++) {
+        unchecked(arr[i] = nextInt53Number());
+    }
+}
+export function fillFloat64Array_Int32Numbers(arr: Float64Array): void {
+    for (let i: i32 = 0; i < arr.length; i++) {
+        unchecked(arr[i] = nextInt32Number());
     }
 }
 

--- a/src/assembly/xoshiro256plus-simd.ts
+++ b/src/assembly/xoshiro256plus-simd.ts
@@ -1,5 +1,5 @@
-import { number, coord, coordSquared, JUMP_256 } from './common';
-import { numbers, point, pointSquared } from './common-simd';
+import { int32Number, int53Number, number, coord, coordSquared, JUMP_256 } from './common';
+import { int32Numbers, int53Numbers, numbers, point, pointSquared } from './common-simd';
 
 let s0: v128 = i64x2.splat(0);
 let s1: v128 = i64x2.splat(0);
@@ -14,18 +14,20 @@ export function setSeed(
     s1 = i64x2(b, f);
     s2 = i64x2(c, g);
     s3 = i64x2(d, h);
-    nextU64x2();
+    nextInt64x2();
 };
 
-// advances the state by 2^128 steps every call.
-// can be used to generate 2^128 non-overlapping subsequences for parallel computations.
+/**
+ * Advances the state by 2^128 steps every call. Can be used to generate 2^128 
+ * non-overlapping subsequences (with the same seed) for parallel computations.
+ */
 export function jump(): void {
     let jump_s0: v128 = i64x2.splat(0);
     let jump_s1: v128 = i64x2.splat(0);
     let jump_s2: v128 = i64x2.splat(0);
     let jump_s3: v128 = i64x2.splat(0);
   
-    // loop through each 64-bit value in the JUMP_256 array
+    // loop through each 64-bit value in the jump array
     for (let i: i32 = 0; i < JUMP_256.length; i++) {
         // loop through each bit of the jump value, and if bit is 1, compute a new jump state
         for (let b: i32 = 0; b < 64; b++) {
@@ -35,7 +37,7 @@ export function jump(): void {
                 jump_s2 = v128.xor(jump_s2, s2);
                 jump_s3 = v128.xor(jump_s3, s3);
             }
-            nextU64x2();
+            nextInt64x2();
         }
     }
   
@@ -48,7 +50,7 @@ export function jump(): void {
 
 // return 2 random u64 numbers
 @inline
-export function nextU64x2(): v128 {
+export function nextInt64x2(): v128 {
     const result: v128 = v128.add<u64>(s0, s3);
 
     // Shift
@@ -73,50 +75,66 @@ export function nextU64x2(): v128 {
  * we inline and optimize the build at compile time.
  */
 @inline
+export function nextInt53x2(): v128 {
+    return int53Numbers(nextInt64x2());
+}
+
+@inline
+export function nextInt32x2(): v128 {
+    return int32Numbers(nextInt64x2());
+}
+
+@inline
 export function nextNumbers(): v128 {
-    return numbers(nextU64x2());
+    return numbers(nextInt64x2());
 }
 
 @inline
 export function nextPoint(): v128 {
-    return point(nextU64x2());
+    return point(nextInt64x2());
 }
 
 @inline
 export function nextPointSquared(): v128 {
-    return pointSquared(nextU64x2());
+    return pointSquared(nextInt64x2());
 }
 
-/**
- * Single-number functions are provided for interface compatibility, but
- * do not actually take advantage of parallelization achieved with SIMD.
- */
+// Single-number functions are provided for interface compatibility, but
+// do not actually take advantage of parallelization achieved with SIMD
 @inline
-export function next(): u64 {
-    return v128.extract_lane<u64>(nextU64x2(), 0);
+export function nextInt64(): u64 {
+    return v128.extract_lane<u64>(nextInt64x2(), 0);
+}
+
+@inline
+export function nextInt53Number(): f64 {
+    return int53Number(nextInt64());
+}
+
+@inline
+export function nextInt32Number(): f64 {
+    return int32Number(nextInt64());
 }
 
 @inline
 export function nextNumber(): f64 {
-    return number(v128.extract_lane<u64>(nextU64x2(), 0));
+    return number(v128.extract_lane<u64>(nextInt64x2(), 0));
 }
 
 @inline
 export function nextCoord(): f64 {
-    return coord(v128.extract_lane<u64>(nextU64x2(), 0));
+    return coord(v128.extract_lane<u64>(nextInt64x2(), 0));
 }
 
 @inline
 export function nextCoordSquared(): f64 {
-    return coordSquared(v128.extract_lane<u64>(nextU64x2(), 0));
+    return coordSquared(v128.extract_lane<u64>(nextInt64x2(), 0));
 }
 
-/**
- * Expose array management functions from this module.
- */
+// Expose array management functions from this module
 export { allocUint64Array, allocFloat64Array, freeArray } from './common';
 
-/**
+/*
  * If we extract the following mostly-repeated functions to shared logic, 
  * define a type for the function, and pass the generator function as a 
  * parameter, it runs somewhat slower because of runtime function call overhead
@@ -129,7 +147,7 @@ export { allocUint64Array, allocFloat64Array, freeArray } from './common';
  *  Everything slows down. So we opt instead for static functions and speed.
  */
 
-// Monte Carlo test: Count how many random points fall inside a unit circle
+/** Monte Carlo test: Count how many random points fall inside a unit circle */
 export function batchTestUnitCirclePoints(pointCount: i32): i32 {
     let pointsInCircle: i32 = 0;
     let pSquared: v128;
@@ -153,9 +171,29 @@ export function fillUint64Array(arr: Uint64Array): void {
     let rand: v128;
 
     for (let i: i32 = 0; i < arr.length - 1; i += 2) {
-        rand = nextU64x2();
+        rand = nextInt64x2();
         unchecked(arr[i] = v128.extract_lane<u64>(rand, 0));
         unchecked(arr[i + 1] = v128.extract_lane<u64>(rand, 1));
+    }
+}
+
+export function fillFloat64Array_Int53Numbers(arr: Float64Array): void {
+    let rand: v128;
+
+    for (let i: i32 = 0; i < arr.length - 1; i += 2) {
+        rand = nextInt53x2();
+        unchecked(arr[i] = v128.extract_lane<f64>(rand, 0));
+        unchecked(arr[i + 1] = v128.extract_lane<f64>(rand, 1));
+    }
+}
+
+export function fillFloat64Array_Int32Numbers(arr: Float64Array): void {
+    let rand: v128;
+
+    for (let i: i32 = 0; i < arr.length - 1; i += 2) {
+        rand = nextInt32x2();
+        unchecked(arr[i] = v128.extract_lane<f64>(rand, 0));
+        unchecked(arr[i + 1] = v128.extract_lane<f64>(rand, 1));
     }
 }
 

--- a/src/random-generator.js
+++ b/src/random-generator.js
@@ -1,7 +1,7 @@
 import { seed64Array } from './seeds.js';
 
-// @rollup/plugin-wasm imports these as base64 strings, and provides us a 
-// function so that each can be compiled and loaded synchronously.
+// @rollup/plugin-wasm imports these binaries as base64 strings, and provides a 
+// function to synchronously compile and instantiate each WASM generator.
 import PCG from '../bin/pcg.wasm';
 import Xoroshiro128Plus from '../bin/xoroshiro128plus.wasm';
 import Xoroshiro128Plus_SIMD from '../bin/xoroshiro128plus-simd.wasm';
@@ -10,7 +10,7 @@ import Xoshiro256Plus_SIMD from '../bin/xoshiro256plus-simd.wasm';
 
 /**
  * @enum {string} PRNG Algorithm Type
- * */
+ */
 export const PRNGType = {
     PCG: 'PCG',
     Xoroshiro128Plus: 'Xoroshiro128Plus',
@@ -145,55 +145,108 @@ export class RandomGenerator {
 
     /**
      * Get the generator's next unsigned 64-bit integer
-     * @returns {bigint} An unsigned `bigint` providing 64-bits of 
-     * randomness.
+     * @returns {bigint} An unsigned `bigint` providing 64-bits of randomness,
+     * between 0 and 2^64 - 1
      */
     nextBigInt() {
         // `u64` return type in WASM is treated as an `i64` and converted to a
         // signed BigInt in JS, so we mask it before returning to ensure the 
         // value is treated as unsigned
-        return this.#instance.next() & 0xFFFFFFFFFFFFFFFFn;
+        return this.#instance.nextInt64() & 0xFFFFFFFFFFFFFFFFn;
     }
 
     /**
-     * Get the generator's next Float number in range [0, 1)
-     * @returns {number} A Float between 0 and 1
+     * Get the generator's next unsigned 53-bit integer
+     * @returns {number} An unsigned integer `number` providing 53-bits of 
+     * randomness (the most we can fit into a JavaScript `number`), between
+     * 0 and 2^53 - 1 (i.e. `Number.MAX_SAFE_INTEGER`)
+     */
+    nextIntegerNumber() {
+        // bit-shifted and returned as an f64 from WASM, so we get an unsigned
+        // integer that fits nicely into a `number` without any more work
+        return this.#instance.nextInt53Number();
+    }
+
+   /**
+     * Get the generator's next unsigned 32-bit integer
+     * @returns {number} An unsigned integer `number` providing 32-bits of 
+     * randomness, between 0 and 2^32 - 1
+     */
+   nextInteger32Number() {
+    // bit-shifted and returned as an f64 from WASM, so we get an unsigned
+    // integer that fits nicely into a `number` without any more work
+    return this.#instance.nextInt32Number();
+}
+
+    /**
+     * Get the generator's next floating point number in range [0, 1)
+     * @returns {number} A floating point `number` between 0 and 1
      */
     nextNumber() {
         return this.#instance.nextNumber();
     }
 
     /**
-     * Get the generator's next Float number in range (-1, 1). Can be viewed
-     * as a "coordinate" in a unit circle. Useful for Monte Carlo simulation.
-     * @returns {number} A Float between -1 and 1
+     * Get the generator's next floating point number in range (-1, 1). 
+     * Can be viewed as a "coordinate" in a unit circle. Useful for Monte
+     * Carlo simulation.
+     * @returns {number} A floating point `number` between -1 and 1
      */
     nextCoord() {
         return this.#instance.nextCoord();
     }
 
     /**
-     * Get the square of the generator's next Float number in range (-1, 1).
-     * Useful for Monte Carlo simulation.
-     * @returns {number} A Float between -1 and 1 multiplied by itself
+     * Get the square of the generator's next floating point number in range
+     * (-1, 1). Useful for Monte Carlo simulation.
+     * @returns {number} A floating point `number` between -1 and 1, multiplied
+     * by itself
      */
     nextCoordSquared() {
         return this.#instance.nextCoordSquared();
     }
 
     /**
-     * Get the generator's next set of 64-bit integers. Array size is set when
-     * generator is created, or by changing {@link outputArraySize}.
-     * @returns {BigUint64Array} An array of `u64` values in WASM viewed as
-     * unsigned `bigint` values. This output buffer is reused with each call.
+     * Get the generator's next set of 64-bit integers between
+     * 0 and 2^64 - 1. Array size is set when generator is created, 
+     * or by changing {@link outputArraySize}.
+     * @returns {BigUint64Array} An array of 64-bit integers, represented as 
+     * `u64` values in WASM and viewed as unsigned `bigint` values in
+     * JavaScript. This output buffer is reused with each call.
      */
-    nextArray_BigInt() {
-        this.#instance.fillUint64Array(this.#bigIntOutputArrayPtr);
+    nextArray_BigInts() {
+        this.#instance.fillUint64Array_Int64(this.#bigIntOutputArrayPtr);
         return this.#bigIntOutputArray;
+    }
+    
+    /**
+     * Get the generator's next set of 53-bit integers between
+     * 0 and 2^53 - 1 (i.e. `Number.MAX_SAFE_INTEGER`). Array size is set
+     * when generator is created, or by changing {@link outputArraySize}.
+     * @returns {Float64Array} An array of 53-bit integers, represented as
+     * `f64` values in WASM so they can be viewed as `number` values in
+     * JavaScript. This output buffer is reused with each call.
+     */
+    nextArray_IntegerNumbers() {
+        this.#instance.fillFloat64Array_Int53Numbers(this.#floatOutputArrayPtr);
+        return this.#floatOutputArray;
+    }
+    
+    /**
+     * Get the generator's next set of 32-bit integers between
+     * 0 and 2^32 - 1. Array size is set when generator is created, 
+     * or by changing {@link outputArraySize}.
+     * @returns {Float64Array} An array of 32-bit integers, represented as
+     * `f64` values in WASM so they can be viewed as `number` values in
+     * JavaScript. This output buffer is reused with each call.
+     */
+    nextArray_Integer32Numbers() {
+        this.#instance.fillFloat64Array_Int32Numbers(this.#floatOutputArrayPtr);
+        return this.#floatOutputArray;
     }
 
     /**
-     * Get the generator's next set of Float numbers in range [0, 1).
+     * Get the generator's next set of floating point numbers in range [0, 1).
      * Array size is set when generator is created, or by changing 
      * {@link outputArraySize}.
      * @returns {Float64Array} An array of `f64` values in WASM viewed as
@@ -229,13 +282,13 @@ export class RandomGenerator {
     }
 
     /**
-     * Perform a batch test of random (x, y) points between -1 and 1 to see
-     * if they fall within the corresponding unit circle of radius 1.
+     * Perform a batch test in WASM of random (x, y) points between -1 and 1
+     * and check if they fall within the corresponding unit circle of radius 1.
      * Useful for Monte Carlo simulation.
      * @param {number} pointCount Number of random (x, y) points to generate
      * and test
      * @returns {number} Number of tested points which fall inside of the
-     * unit circle.  
+     * unit circle.
      */
     batchTestUnitCirclePoints(pointCount) {
         return this.#instance.batchTestUnitCirclePoints(pointCount);

--- a/src/random-generator.js
+++ b/src/random-generator.js
@@ -73,6 +73,7 @@ export class RandomGenerator {
     /**
      * Creates a seedable pseudo random number generator that 
      * runs in WebAssembly.
+     * 
      * @param {PRNGType} prngType The PRNG algorithm to use. Defaults to 
      * Xoroshiro128Plus.
      * @param {Array<bigint>} seeds Collection of 64-bit integers used to seed 
@@ -145,6 +146,7 @@ export class RandomGenerator {
 
     /**
      * Get the generator's next unsigned 64-bit integer
+     * 
      * @returns {bigint} An unsigned `bigint` providing 64-bits of randomness,
      * between 0 and 2^64 - 1
      */
@@ -157,29 +159,31 @@ export class RandomGenerator {
 
     /**
      * Get the generator's next unsigned 53-bit integer
+     * 
      * @returns {number} An unsigned integer `number` providing 53-bits of 
      * randomness (the most we can fit into a JavaScript `number`), between
-     * 0 and 2^53 - 1 (i.e. `Number.MAX_SAFE_INTEGER`)
+     * 0 and 2^53 - 1 (`Number.MAX_SAFE_INTEGER`)
      */
-    nextIntegerNumber() {
+    nextInteger() {
         // bit-shifted and returned as an f64 from WASM, so we get an unsigned
-        // integer that fits nicely into a `number` without any more work
+        // integer that fits nicely into a `number` without any more transformation
         return this.#instance.nextInt53Number();
     }
 
-   /**
+    /**
      * Get the generator's next unsigned 32-bit integer
      * @returns {number} An unsigned integer `number` providing 32-bits of 
      * randomness, between 0 and 2^32 - 1
      */
-   nextInteger32Number() {
-    // bit-shifted and returned as an f64 from WASM, so we get an unsigned
-    // integer that fits nicely into a `number` without any more work
-    return this.#instance.nextInt32Number();
-}
+    nextInteger32() {
+        // bit-shifted and returned as an f64 from WASM, so we get an unsigned
+        // integer that fits nicely into a `number` without any more transformation
+        return this.#instance.nextInt32Number();
+    }
 
     /**
      * Get the generator's next floating point number in range [0, 1)
+     * 
      * @returns {number} A floating point `number` between 0 and 1
      */
     nextNumber() {
@@ -187,9 +191,10 @@ export class RandomGenerator {
     }
 
     /**
-     * Get the generator's next floating point number in range (-1, 1). 
-     * Can be viewed as a "coordinate" in a unit circle. Useful for Monte
+     * Get the generator's next floating point number in range (-1, 1).
+     * Can be considered a "coordinate" in a unit circle. Useful for Monte
      * Carlo simulation.
+     * 
      * @returns {number} A floating point `number` between -1 and 1
      */
     nextCoord() {
@@ -199,6 +204,7 @@ export class RandomGenerator {
     /**
      * Get the square of the generator's next floating point number in range
      * (-1, 1). Useful for Monte Carlo simulation.
+     * 
      * @returns {number} A floating point `number` between -1 and 1, multiplied
      * by itself
      */
@@ -210,11 +216,12 @@ export class RandomGenerator {
      * Get the generator's next set of 64-bit integers between
      * 0 and 2^64 - 1. Array size is set when generator is created, 
      * or by changing {@link outputArraySize}.
+     * 
      * @returns {BigUint64Array} An array of 64-bit integers, represented as 
      * `u64` values in WASM and viewed as unsigned `bigint` values in
      * JavaScript. This output buffer is reused with each call.
      */
-    nextArray_BigInts() {
+    nextArray_BigInt() {
         this.#instance.fillUint64Array_Int64(this.#bigIntOutputArrayPtr);
         return this.#bigIntOutputArray;
     }
@@ -227,7 +234,7 @@ export class RandomGenerator {
      * `f64` values in WASM so they can be viewed as `number` values in
      * JavaScript. This output buffer is reused with each call.
      */
-    nextArray_IntegerNumbers() {
+    nextArray_Integer() {
         this.#instance.fillFloat64Array_Int53Numbers(this.#floatOutputArrayPtr);
         return this.#floatOutputArray;
     }
@@ -240,7 +247,7 @@ export class RandomGenerator {
      * `f64` values in WASM so they can be viewed as `number` values in
      * JavaScript. This output buffer is reused with each call.
      */
-    nextArray_Integer32Numbers() {
+    nextArray_Integer32() {
         this.#instance.fillFloat64Array_Int32Numbers(this.#floatOutputArrayPtr);
         return this.#floatOutputArray;
     }
@@ -252,7 +259,7 @@ export class RandomGenerator {
      * @returns {Float64Array} An array of `f64` values in WASM viewed as
      * `number` values. This output buffer is reused with each call.
      */
-    nextArray_Numbers() {
+    nextArray_Number() {
         this.#instance.fillFloat64Array_Numbers(this.#floatOutputArrayPtr);
         return this.#floatOutputArray;
     }
@@ -264,7 +271,7 @@ export class RandomGenerator {
      * @returns {Float64Array} An array of `f64` values in WASM viewed as
      * `number` values. This output buffer is reused with each call.
      */
-    nextArray_Coords() {
+    nextArray_Coord() {
         this.#instance.fillFloat64Array_Coords(this.#floatOutputArrayPtr);
         return this.#floatOutputArray;
     }
@@ -276,7 +283,7 @@ export class RandomGenerator {
      * @returns {Float64Array} An array of `f64` values in WASM viewed as
      * `number` values. This output buffer is reused with each call.
      */
-    nextArray_CoordsSquared() {
+    nextArray_CoordSquared() {
         this.#instance.fillFloat64Array_CoordsSquared(this.#floatOutputArrayPtr);
         return this.#floatOutputArray;
     }


### PR DESCRIPTION
Began adding nextInt32 and nextInt53, and ended up making a couple more changes to refactor/cleanup the API. 

BREAKING CHANGES:
- Normalize JS array interface to use the same name scheme for array and single value functions, so that all single functions of `nextTYPE()` have a corresponding `nextArray_TYPE()` function
- Rename AS `next` to `nextInt64`
- Rename AS `nextu64x2` to `nextInt64x2`

Extend AssemblyScript generator interface:
 - Add `nextInt53`
 - Add `nextInt32`

Extend JS `RandomGenerator` interface:
 - Add `nextInteger` 
 - Add `nextInteger32`
 - Add `nextArray_Integer`
 - Add `nextArray_Integer32`

Misc:
- docs: Update examples, compatibility, demos, and roadmap
- chore: Fix assemblyscript dependency to get patch updates only
- demo: make pmc use local fast-prng-wasm dependency and update ArrayFill mode for changed function name