### PR TITLE
PCG Stream Select and Xoshiro256Plus_SIMD array fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,17 @@ const seededGen3 = new RandomGenerator(PRNGType.Xoshiro256Plus, sharedSeeds, jum
 const num3 = seededGen3.nextNumber();
 
 console.log(num1 === num3);           // false
+
+// 4) uses the same shared seed set, but also chooses a unique PCG stream
+const streamIncrement1 = 17;
+const pcgGen1 = new RandomGenerator(PRNGType.PCG, sharedSeeds, streamIncrement1);
+const pcgNum1 = pcgGen1.nextNumber();
+
+const streamIncrement2 = 12345678901234n;
+const pcgGen2 = new RandomGenerator(PRNGType.PCG, sharedSeeds, streamIncrement2);
+const pcgNum2 = pcgGen2.nextNumber();
+
+console.log(pcgNum1 === pcgNum2);     // false
 ```
 
 ### Array Output

--- a/src/assembly/pcg.ts
+++ b/src/assembly/pcg.ts
@@ -1,12 +1,28 @@
 import { int32Number, int53Number, number, coord, coordSquared } from './common';
 
-const MUL: u64 = 6364136223846793005;
-const INC: u64 = 1442695040888963407;
+const MULTIPLIER: u64 = 6364136223846793005;
+
+// In PCG, unique increment provides a unique stream.
+// This number must ALWAYS BE ODD!
+let increment: u64 = 1442695040888963407;
 
 let state: u64 = 0;
 
 export function setSeed(seed: u64): void {
     state = seed;
+    nextInt32();
+}
+
+/**
+ * Choose the unique stream to be provided by this generator.
+ * @param inc Any integer, provided it is unique amongst stream increments 
+ * used for other generator instances, if you want them to remain unique.
+ */
+export function setStreamIncrement(inc: u64): void {
+    // ensure the increment is odd regardless of value given
+    increment = (inc << 1) | 1;
+
+    // advance state
     nextInt32();
 }
 
@@ -18,7 +34,7 @@ export function setSeed(seed: u64): void {
 export function nextInt32(): u32 {
     const oldState: u64 = state;
 
-    state = oldState * MUL + INC;
+    state = oldState * MULTIPLIER + increment;
 
     // Calculate output function (XSH RR)
     const xorshifted: u32 = <u32>(((oldState >> 18) ^ oldState) >> 27);
@@ -46,7 +62,7 @@ export function nextInt53Number(): f64 {
 
 @inline
 export function nextInt32Number(): f64 {
-    return int32Number(nextInt64());
+    return <f64>nextInt32();
 }
 
 @inline

--- a/src/assembly/xoshiro256plus-simd.ts
+++ b/src/assembly/xoshiro256plus-simd.ts
@@ -167,7 +167,7 @@ export function batchTestUnitCirclePoints(pointCount: i32): i32 {
     return pointsInCircle;
 }
 
-export function fillUint64Array(arr: Uint64Array): void {
+export function fillUint64Array_Int64(arr: Uint64Array): void {
     let rand: v128;
 
     for (let i: i32 = 0; i < arr.length - 1; i += 2) {


### PR DESCRIPTION
1. This implements the "PCG Jump" feature not actually as a state jump, but rather as setting the internal stream increment. 

2. Additionally, this fixes a xoshiro256plus-simd regression issue introduced in 0.4.0 by 
updating `fillUint64Array` to `fillUint64Array_Int64` to correctly reflect the AS generator interface change. 
- Future releases plan to address this in compilation (TS type checking by having the AS generators adhere to the same interface), and with unit tests to prevent regression bugs

3. Finally, this updates PCG's `nextInt32Number` implementation to use its native 32bit generator function

