### PR TITLE
Bug Fixes

### DIFF
--- a/docs/fast-prng-wasm/namespaces/PCG.md
+++ b/docs/fast-prng-wasm/namespaces/PCG.md
@@ -170,6 +170,9 @@ function setSeeds(seed): void;
 
 Initializes this generator's internal state with the provided random seed.
 
+TODO: This seeding implementation may currently differ from the PCG 
+reference implementation's seeding pattern.
+
 #### Parameters
 
 | Parameter | Type |

--- a/src/assembly/common/conversion-simd.ts
+++ b/src/assembly/common/conversion-simd.ts
@@ -14,7 +14,8 @@ export function uint64x2_to_uint53AsFloatx2(next: v128): v128 {
     // Shift right by 11 (>> 11) to extract upper 53 bits
     // of each output (highest quality randomness in upper,
     // and JS `number` only supports 53 bit precision)
-    const randShifted: v128 = v128.shr<u64>(next, 11);
+    // Use i64x2.shr_u for unsigned/logical right shift (v128.shr is signed/arithmetic)
+    const randShifted: v128 = i64x2.shr_u(next, 11);
 
     // extract bit-shifted `u64`s and cast to `f64`s
     return f64x2(
@@ -32,7 +33,8 @@ export function uint64x2_to_uint53AsFloatx2(next: v128): v128 {
 export function uint64x2_to_uint32AsFloatx2(next: v128): v128 {
     // Shift right by 32 (>> 32) to extract upper 32 bits
     // of each output (highest quality randomness in upper)
-    const randShifted: v128 = v128.shr<u64>(next, 32);
+    // Use i64x2.shr_u for unsigned/logical right shift (v128.shr is signed/arithmetic)
+    const randShifted: v128 = i64x2.shr_u(next, 32);
 
     // extract bit-shifted `u64`s and cast to `f64`s
     return f64x2(

--- a/src/assembly/common/conversion.ts
+++ b/src/assembly/common/conversion.ts
@@ -17,7 +17,8 @@ export const JUMP_256: StaticArray<u64> = [0x180ec6d33cfd0aba, 0xd5a61266f0c9392
 // @ts-ignore: top level decorators are supported in AssemblyScript
 @inline
 export function uint64_to_uint53AsFloat(next: u64): f64 {
-    // note: >>> is a logical right shift, which fills high bits with 0s
+    // Use >>> for unsigned/logical right shift which fills high bits with 0s
+    // >> in AssemblyScript is signed/arithmetic shift
     return <f64>(next >>> 11);
 }
 
@@ -28,7 +29,8 @@ export function uint64_to_uint53AsFloat(next: u64): f64 {
 // @ts-ignore: top level decorators are supported in AssemblyScript
 @inline
 export function uint64_to_uint32AsFloat(next: u64): f64 {
-    // note: >>> is a logical right shift, which fills high bits with 0s
+    // Use >>> for unsigned/logical right shift which fills high bits with 0s
+    // >> in AssemblyScript is signed/arithmetic shift
     return <f64>(next >>> 32);
 }
 
@@ -38,7 +40,8 @@ export function uint64_to_uint32AsFloat(next: u64): f64 {
 // @ts-ignore: top level decorators are supported in AssemblyScript
 @inline
 export function uint64_to_float53(next: u64): f64 {
-    // note: >>> is a logical right shift , which fills high bits with 0s
+    // Use >>> for unsigned/logical right shift which fills high bits with 0s
+    // >> in AssemblyScript is signed/arithmetic shift
     return <f64>(next >>> 11) / BIT_53;
 }
 

--- a/src/assembly/common/memory.ts
+++ b/src/assembly/common/memory.ts
@@ -48,14 +48,18 @@ export function allocFloat64Array(count: i32): usize {
 }
 
 /**
- * Frees WebAssembly memory that was previously allocated by {@link allocUint64Array} 
+ * Frees WebAssembly memory that was previously allocated by {@link allocUint64Array}
  * or {@link allocFloat64Array}.
- * 
+ *
  * @param arrPtr A pointer to a previously allocated WASM memory array for cleanup.
  */
 // @ts-ignore: top level decorators are supported in AssemblyScript
 @inline
 export function freeArray(arrPtr: usize): void {
     // @ts-ignore: it won't find __unpin
+    // allow WASM runtime GC to free the array
     __unpin(arrPtr);
+    // @ts-ignore: it won't find __free
+    // explicitly free memory in stub runtime where no GC is available
+    __free(arrPtr);
 }

--- a/src/assembly/prng/pcg.ts
+++ b/src/assembly/prng/pcg.ts
@@ -37,7 +37,12 @@ let state: u64 = 0;
 /** Number of seeds required for this generator's {@link setSeeds} function. */
 export const SEED_COUNT: i32 = 1;
 
-/** Initializes this generator's internal state with the provided random seed. */
+/**
+ * Initializes this generator's internal state with the provided random seed.
+ *
+ * TODO: This seeding implementation may currently differ from the PCG 
+ * reference implementation's seeding pattern.
+ */
 // @ts-ignore: top level decorators are supported in AssemblyScript
 @inline
 export function setSeeds(seed: u64): void {

--- a/src/assembly/prng/pcg.ts
+++ b/src/assembly/prng/pcg.ts
@@ -83,7 +83,8 @@ export function uint32(): u32 {
     const rot: u32 = <u32>(oldState >>> 59);
 
     // 32-bit branch-free rotate right
-    // note: >>> is a logical right shift, which fills high bits with 0s
+    // Use >>> for unsigned/logical right shift which fills high bits with 0s
+    // >> in AssemblyScript is signed/arithmetic shift
     return (xorshifted >>> rot) | (xorshifted << ((-rot) & 31));
 }
 

--- a/src/assembly/prng/xoroshiro128plus-simd.ts
+++ b/src/assembly/prng/xoroshiro128plus-simd.ts
@@ -99,13 +99,15 @@ export function uint64x2(): v128 {
     const t: v128 = v128.xor(s1, s0);
 
     // s0 = ((s0 << 24) | (s0 >> 40)) ^ t ^ (t << 16);
-    const rot = v128.or( v128.shl<u64>(s0, 24), v128.shr<u64>(s0, 40) );
+    // Use i64x2.shr_u for unsigned/logical right shift (v128.shr is signed/arithmetic)
+    const rot = v128.or( v128.shl<u64>(s0, 24), i64x2.shr_u(s0, 40) );
     s0 = v128.xor( rot, v128.xor(t, v128.shl<u64>(t, 16)) );
-    
+
     // s1 = ((t << 37) | (t >> 27));
     s1 = v128.or(
         v128.shl<u64>(t, 37),
-        v128.shr<u64>(t, 27)
+        // Use i64x2.shr_u for unsigned/logical right shift (v128.shr is signed/arithmetic)
+        i64x2.shr_u(t, 27)
     )
 
     return result;

--- a/src/assembly/prng/xoroshiro128plus-simd.ts
+++ b/src/assembly/prng/xoroshiro128plus-simd.ts
@@ -52,7 +52,6 @@ export const SEED_COUNT: i32 = 4;
 export function setSeeds(a: u64, b: u64, c: u64, d: u64): void {
     s0 = i64x2(a, c);
     s1 = i64x2(b, d);
-    uint64x2();
 };
 
 /**

--- a/src/assembly/prng/xoroshiro128plus.ts
+++ b/src/assembly/prng/xoroshiro128plus.ts
@@ -36,7 +36,6 @@ export const SEED_COUNT: i32 = 2;
 export function setSeeds(a: u64, b: u64): void {
     s0 = a;
     s1 = b;
-    uint64();
 };
 
 /**

--- a/src/assembly/prng/xoshiro256plus-simd.ts
+++ b/src/assembly/prng/xoshiro256plus-simd.ts
@@ -59,7 +59,6 @@ export function setSeeds(
     s1 = i64x2(b, f);
     s2 = i64x2(c, g);
     s3 = i64x2(d, h);
-    uint64x2();
 };
 
 /**

--- a/src/assembly/prng/xoshiro256plus-simd.ts
+++ b/src/assembly/prng/xoshiro256plus-simd.ts
@@ -119,7 +119,8 @@ export function uint64x2(): v128 {
     s2 = v128.xor(s2, t);
 
     // Rotate: rotl(45) == (sl 45 | sr (64-45))
-    s3 = v128.or(v128.shl<u64>(s3, 45), v128.shr<u64>(s3, 19));
+    // Use i64x2.shr_u for unsigned/logical right shift (v128.shr is signed/arithmetic)
+    s3 = v128.or(v128.shl<u64>(s3, 45), i64x2.shr_u(s3, 19));
 
     return result;
 }

--- a/src/assembly/prng/xoshiro256plus.ts
+++ b/src/assembly/prng/xoshiro256plus.ts
@@ -40,7 +40,6 @@ export function setSeeds(a: u64, b: u64, c: u64, d: u64): void {
     s1 = b;
     s2 = c;
     s3 = d;
-    uint64();
 };
 
 /**


### PR DESCRIPTION
Fixes several bugs:
 - use unsigned right shift (i64x2.shr_u) for correct bit operations on SIMD-enabled algorithms
 - remove initial state advancement after seeding to match reference implementations of xoshiro family generators
 - attempt to explicitly free array memory in addition to unpinning

Tests to verify these fixes forthcoming!