### PR TITLE
Increase seed entropy

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ Some PRNG applications may require several (or very many) instances of a PRNG ru
 See the [`pmc` demo](examples/pmc) for an example that follows this approach, with each generator instance running in a different Node worker thread.
 
 #### Generate a Seed Collection
-If you don't have custom seeds already, the `seed64Array()` function is provided. It returns a `bigint[8]` containing seeds generated with SplitMix64. The initial SplitMix64 seed uses `crypto.getRandomValues()` when available (all modern browsers and Node.js 15+) for strong entropy, falling back to a combination of time and `Math.random()` in older environments. This collection can be provided as the `seeds` argument for any PRNG in this package.
+If you don't have custom seeds already, the `seed64Array()` function is provided. It returns a `bigint[8]` containing seeds generated with SplitMix64. The initial SplitMix64 seed uses `crypto.getRandomValues()` when available (all modern browsers and Node.js 15+) for strong entropy, falling back to combining multiple entropy sources (`Date.now()`, `performance.now()`, and `Math.random()`) in older environments. This collection can be provided as the `seeds` argument for any PRNG in this package.
 
 #### Choose a Unique Stream for Each Parallel Generator
 Sharing seeds between generators assumes you will also provide a unique `uniqueStreamId` argument:

--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ Some PRNG applications may require several (or very many) instances of a PRNG ru
 See the [`pmc` demo](examples/pmc) for an example that follows this approach, with each generator instance running in a different Node worker thread.
 
 #### Generate a Seed Collection
-If you don't have custom seeds already, the `seed64Array()` function is provided. It returns a `bigint[8]` containing seeds generated with SplitMix64 (which in turn was seeded with a combination of the current time and JavaScript's `Math.random()`). This collection can be provided as the `seeds` argument for any PRNG in this package.
+If you don't have custom seeds already, the `seed64Array()` function is provided. It returns a `bigint[8]` containing seeds generated with SplitMix64. The initial SplitMix64 seed uses `crypto.getRandomValues()` when available (all modern browsers and Node.js 15+) for strong entropy, falling back to a combination of time and `Math.random()` in older environments. This collection can be provided as the `seeds` argument for any PRNG in this package.
 
 #### Choose a Unique Stream for Each Parallel Generator
 Sharing seeds between generators assumes you will also provide a unique `uniqueStreamId` argument:

--- a/docs/js-api.md
+++ b/docs/js-api.md
@@ -414,7 +414,7 @@ the other generators in this library.
 | Parameter | Type | Default value | Description |
 | ------ | ------ | ------ | ------ |
 | `count` | `number` | `8` | Number of random seeds to generate. |
-| `seed` | `number` \| `bigint` \| `null` | `null` | Seed for SplitMix64 generator initialization. If not provided, will auto-seed using a combination of the current time and Math.random(). |
+| `seed` | `number` \| `bigint` \| `null` | `null` | Seed for SplitMix64 generator initialization. If not provided, will auto-seed using crypto.getRandomValues() when available (all modern browsers and Node.js 15+), falling back to a combination of timing sources and Math.random() in older environments. |
 
 #### Returns
 

--- a/src/assembly/common/conversion.ts
+++ b/src/assembly/common/conversion.ts
@@ -17,8 +17,7 @@ export const JUMP_256: StaticArray<u64> = [0x180ec6d33cfd0aba, 0xd5a61266f0c9392
 // @ts-ignore: top level decorators are supported in AssemblyScript
 @inline
 export function uint64_to_uint53AsFloat(next: u64): f64 {
-    // Use >>> for unsigned/logical right shift which fills high bits with 0s
-    // >> in AssemblyScript is signed/arithmetic shift
+    // >>> always performs logical shift (zero-fill); >> depends on operand signedness in AS
     return <f64>(next >>> 11);
 }
 
@@ -29,8 +28,7 @@ export function uint64_to_uint53AsFloat(next: u64): f64 {
 // @ts-ignore: top level decorators are supported in AssemblyScript
 @inline
 export function uint64_to_uint32AsFloat(next: u64): f64 {
-    // Use >>> for unsigned/logical right shift which fills high bits with 0s
-    // >> in AssemblyScript is signed/arithmetic shift
+    // >>> always performs logical shift (zero-fill); >> depends on operand signedness in AS
     return <f64>(next >>> 32);
 }
 
@@ -40,8 +38,7 @@ export function uint64_to_uint32AsFloat(next: u64): f64 {
 // @ts-ignore: top level decorators are supported in AssemblyScript
 @inline
 export function uint64_to_float53(next: u64): f64 {
-    // Use >>> for unsigned/logical right shift which fills high bits with 0s
-    // >> in AssemblyScript is signed/arithmetic shift
+    // >>> always performs logical shift (zero-fill); >> depends on operand signedness in AS
     return <f64>(next >>> 11) / BIT_53;
 }
 

--- a/src/assembly/prng/pcg.ts
+++ b/src/assembly/prng/pcg.ts
@@ -112,8 +112,7 @@ export function uint32(): u32 {
     const rot: u32 = <u32>(oldState >>> 59);
 
     // 32-bit branch-free rotate right
-    // Use >>> for unsigned/logical right shift which fills high bits with 0s
-    // >> in AssemblyScript is signed/arithmetic shift
+    // >>> always performs logical shift (zero-fill); >> depends on operand signedness in AS
     return (xorshifted >>> rot) | (xorshifted << ((-rot) & 31));
 }
 

--- a/src/assembly/test/conversion.test.ts
+++ b/src/assembly/test/conversion.test.ts
@@ -71,7 +71,7 @@ describe('uint64_to_float53', () => {
     const highBitSet: u64 = 0xFFFFFFFFFFFFFFFF;
     const result = uint64_to_float53(highBitSet);
 
-    assertGreaterThanOrEqual(result, 0, "Unsigned shift keeps result positive");
+    assertGreaterThanOrEqual(result, 0, "Logical shift (>>>) preserves unsigned value");
     assertLessThan(result, 1, "Still within [0, 1) range");
     assertGreaterThan(result, MAX_UINT64_TO_FLOAT_LOWER_BOUND, "Max u64 produces value very close to 1");
   });

--- a/src/seeds.ts
+++ b/src/seeds.ts
@@ -21,11 +21,11 @@ function seed32(): number {
 
     // Add performance.now() if available (microsecond precision gives us more bits of randomness)
     if (typeof performance !== 'undefined' && performance.now) {
-        entropy ^= (performance.now() * 1000000) | 0;  // | 0 converts float to int32
+        entropy ^= (performance.now() * 1000000) | 0;  // Scale to microseconds, then | 0 converts float to int32
     }
 
     // Mix in Math.random()
-    entropy ^= (Math.random() * 0x100000000) | 0;  // | 0 converts float to int32
+    entropy ^= (Math.random() * 0x100000000) | 0;  // Scale to 32-bit range, then | 0 converts float to int32
 
     // >>> 0 ensures unsigned 32-bit: bitwise operations produce signed int32, but seeds must be unsigned
     return entropy >>> 0;
@@ -95,12 +95,14 @@ export class SplitMix64 {
 /**
  * Generates an array of random 64-bit integers suitable for seeding
  * the other generators in this library.
- * 
+ *
  * @param count Number of random seeds to generate.
- * 
+ *
  * @param seed Seed for SplitMix64 generator initialization. If not provided,
- * will auto-seed using a combination of the current time and Math.random().
- * 
+ * will auto-seed using crypto.getRandomValues() when available (all modern browsers
+ * and Node.js 15+), falling back to a combination of timing sources and Math.random()
+ * in older environments.
+ *
  * @returns Array of unique 64-bit seeds.
  */
 export function seed64Array(count = 8, seed: number | bigint | null = null): bigint[] {

--- a/src/seeds.ts
+++ b/src/seeds.ts
@@ -1,9 +1,46 @@
+/**
+ * Generate a random 32-bit unsigned integer for seeding.
+ *
+ * Uses crypto.getRandomValues() when available (browsers and Node.js 15+)
+ * for cryptographically secure random values. Falls back to Date.now() +
+ * Math.random() in older environments.
+ *
+ * @returns Random unsigned 32-bit integer (0 to 0xFFFFFFFF)
+ */
 function seed32(): number {
-    return Date.now() ^ (Math.random() * 0x100000000);
+    // Use cryptographically secure random if available
+    if (typeof crypto !== 'undefined' && crypto.getRandomValues) {
+        const arr = new Uint32Array(1);
+        crypto.getRandomValues(arr);
+        return arr[0];
+    }
+
+    // Fallback for environments without crypto
+    // >>> 0 ensures unsigned 32-bit: bitwise XOR (^) produces signed int32, but seeds must be unsigned
+    return (Date.now() ^ (Math.random() * 0x100000000)) >>> 0;
 }
 
+/**
+ * Generate a random 64-bit unsigned integer for seeding.
+ *
+ * Uses crypto.getRandomValues() when available for cryptographically
+ * secure random values. Falls back to combining two seed32() calls
+ * in older environments.
+ *
+ * @returns Random unsigned 64-bit integer as BigInt
+ */
 function seed64(): bigint {
-    return (BigInt(seed32()) << 32n) | BigInt(seed32());
+    // Use cryptographically secure random if available
+    if (typeof crypto !== 'undefined' && crypto.getRandomValues) {
+        const arr = new Uint32Array(2);
+        crypto.getRandomValues(arr);
+        return (BigInt(arr[0]) << 32n) | BigInt(arr[1]);
+    }
+
+    // Fallback for environments without crypto
+    const high = seed32();
+    const low = seed32();
+    return (BigInt(high) << 32n) | BigInt(low);
 }
 
 

--- a/src/seeds.ts
+++ b/src/seeds.ts
@@ -9,6 +9,7 @@
  */
 function seed32(): number {
     // Use cryptographically secure random if available
+    /* v8 ignore next 5 - Crypto availability tested via dynamic import */
     if (typeof crypto !== 'undefined' && crypto.getRandomValues) {
         const arr = new Uint32Array(1);
         crypto.getRandomValues(arr);
@@ -41,6 +42,7 @@ function seed32(): number {
  */
 function seed64(): bigint {
     // Use cryptographically secure random if available
+    /* v8 ignore next 5 - Crypto availability tested via dynamic import */
     if (typeof crypto !== 'undefined' && crypto.getRandomValues) {
         const arr = new Uint32Array(2);
         crypto.getRandomValues(arr);

--- a/test/unit/seeds.test.ts
+++ b/test/unit/seeds.test.ts
@@ -13,7 +13,7 @@
  * tests use these utilities to test PRNG behavior with various seed patterns.
  */
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
 import { SplitMix64, seed64Array } from 'fast-prng-wasm';
 
 describe('SplitMix64 Random Seed Generator', () => {
@@ -100,73 +100,155 @@ describe('SplitMix64 Random Seed Generator', () => {
             }
         });
     });
-});
 
-describe('seed64Array', () => {
-    it('should generate array of default size (8)', () => {
-        const seeds = seed64Array();
+    describe('Seeding SplitMix64 Seed Generator with Crypto', () => {
+        afterEach(() => {
+            // Restore all mocks after each test
+            vi.unstubAllGlobals();
+            vi.resetModules();
+        });
 
-        expect(Array.isArray(seeds)).toBe(true);
-        expect(seeds.length).toBe(8);
+        it('should use crypto.getRandomValues when available', async () => {
+            // Mock crypto.getRandomValues to track usage
+            const mockGetRandomValues = vi.fn((arr: Uint32Array) => {
+                // Fill with predictable values for testing
+                for (let i = 0; i < arr.length; i++) {
+                    arr[i] = 0x12345678 + i;
+                }
+                return arr;
+            });
+
+            vi.stubGlobal('crypto', {
+                getRandomValues: mockGetRandomValues,
+            });
+
+            // Dynamically import to get fresh module with mocked crypto
+            const { seed64Array: freshSeed64Array } = await import('../../src/seeds');
+
+            // Generate seeds - should use crypto
+            const seeds = freshSeed64Array(2);
+
+            // Verify crypto.getRandomValues was called
+            expect(mockGetRandomValues).toHaveBeenCalled();
+            expect(seeds.length).toBe(2);
+            expect(seeds.every(s => typeof s === 'bigint')).toBe(true);
+        });
+
+        it('should fall back to Date.now + Math.random when crypto unavailable', async () => {
+            // Remove crypto from global scope
+            vi.stubGlobal('crypto', undefined);
+
+            // Dynamically import to get fresh module without crypto
+            const { seed64Array: freshSeed64Array } = await import('../../src/seeds');
+
+            // Generate seeds - should use fallback
+            const seeds = freshSeed64Array(5);
+
+            // Verify seeds were generated
+            expect(seeds.length).toBe(5);
+            expect(seeds.every(s => typeof s === 'bigint')).toBe(true);
+
+            // Seeds should be unique (statistically very likely)
+            const uniqueSeeds = new Set(seeds);
+            expect(uniqueSeeds.size).toBe(5);
+        });
+
+        it('should generate valid 32-bit values in fallback mode', async () => {
+            // Remove crypto to force fallback
+            vi.stubGlobal('crypto', undefined);
+
+            // Dynamically import to get fresh module
+            const { seed64Array: freshSeed64Array } = await import('../../src/seeds');
+
+            // Generate many auto-seeded instances to test seed32() indirectly
+            const seeds = freshSeed64Array(100);
+
+            // All seeds should be valid bigints
+            expect(seeds.every(s => typeof s === 'bigint')).toBe(true);
+
+            // Seeds should be unique (tests randomness quality)
+            const uniqueSeeds = new Set(seeds);
+            expect(uniqueSeeds.size).toBe(100);
+        });
+
+        it.skipIf(typeof crypto === 'undefined' || !crypto.getRandomValues)(
+            'should produce different values on consecutive calls with crypto',
+            () => {
+                const seeds1 = seed64Array(10);
+                const seeds2 = seed64Array(10);
+
+                // Should be different (statistically guaranteed with crypto RNG)
+                expect(seeds1).not.toEqual(seeds2);
+            }
+        );
     });
 
-    it('should generate array of specified size', () => {
-        const sizes = [1, 2, 4, 10];
+    describe('seed64Array', () => {
+        it('should generate array of default size (8)', () => {
+            const seeds = seed64Array();
 
-        for (const size of sizes) {
-            const seeds = seed64Array(size);
-            expect(seeds.length).toBe(size);
-        }
-    });
+            expect(Array.isArray(seeds)).toBe(true);
+            expect(seeds.length).toBe(8);
+        });
 
-    it('should generate bigint values', () => {
-        const seeds = seed64Array(5);
+        it('should generate array of specified size', () => {
+            const sizes = [1, 2, 4, 10];
 
-        for (const seed of seeds) {
-            expect(typeof seed).toBe('bigint');
-        }
-    });
+            for (const size of sizes) {
+                const seeds = seed64Array(size);
+                expect(seeds.length).toBe(size);
+            }
+        });
 
-    it('should generate unique values', () => {
-        const seeds = seed64Array(100);
-        const uniqueSeeds = new Set(seeds);
+        it('should generate bigint values', () => {
+            const seeds = seed64Array(5);
 
-        // All seeds should be unique (statistically very likely)
-        expect(uniqueSeeds.size).toBe(100);
-    });
+            for (const seed of seeds) {
+                expect(typeof seed).toBe('bigint');
+            }
+        });
 
-    it('should be deterministic with custom seed', () => {
-        const customSeed = 42n;
-        const seeds1 = seed64Array(10, customSeed);
-        const seeds2 = seed64Array(10, customSeed);
+        it('should generate unique values', () => {
+            const seeds = seed64Array(100);
+            const uniqueSeeds = new Set(seeds);
 
-        expect(seeds1).toEqual(seeds2);
-    });
+            // All seeds should be unique (statistically very likely)
+            expect(uniqueSeeds.size).toBe(100);
+        });
 
-    it('should produce different arrays when auto-seeded', () => {
-        const seeds1 = seed64Array(10);
-        const seeds2 = seed64Array(10);
+        it('should be deterministic with custom seed', () => {
+            const customSeed = 42n;
+            const seeds1 = seed64Array(10, customSeed);
+            const seeds2 = seed64Array(10, customSeed);
 
-        // Arrays should be different (statistically very likely)
-        expect(seeds1).not.toEqual(seeds2);
-    });
+            expect(seeds1).toEqual(seeds2);
+        });
 
-    it('should produce known output for known seed', () => {
-        const seeds1 = seed64Array(5, 123n);
-        const seeds2 = seed64Array(5, 123n);
+        it('should produce different arrays when auto-seeded', () => {
+            const seeds1 = seed64Array(10);
+            const seeds2 = seed64Array(10);
 
-        // Same seed should produce same output
-        expect(seeds1).toEqual(seeds2);
+            // Arrays should be different (statistically very likely)
+            expect(seeds1).not.toEqual(seeds2);
+        });
 
-        // Different seed should produce different output
-        const seeds3 = seed64Array(5, 456n);
-        expect(seeds1).not.toEqual(seeds3);
-    });
+        it('should produce known output for known seed', () => {
+            const seeds1 = seed64Array(5, 123n);
+            const seeds2 = seed64Array(5, 123n);
 
-    it('should accept number seed', () => {
-        const seeds = seed64Array(5, 123);
+            // Same seed should produce same output
+            expect(seeds1).toEqual(seeds2);
 
-        expect(Array.isArray(seeds)).toBe(true);
-        expect(seeds.length).toBe(5);
+            // Different seed should produce different output
+            const seeds3 = seed64Array(5, 456n);
+            expect(seeds1).not.toEqual(seeds3);
+        });
+
+        it('should accept number seed', () => {
+            const seeds = seed64Array(5, 123);
+
+            expect(Array.isArray(seeds)).toBe(true);
+            expect(seeds.length).toBe(5);
+        });
     });
 });


### PR DESCRIPTION
Enhance auto-seeding with `crypto.getRandomValues()` better entropy

 - Seed the SplitMix64 seed generator using crypto.getRandomValues() for strong entropy.

 - Falls back to time + Math.random if unavailable.

 - Also ensure only unsigned 32-bit integers are produced with >>> 0 cast in fallback

Enhance seed quality in older environments by adding performance.now() to the fallback entropy mixing